### PR TITLE
Fixed compas_cgal error.

### DIFF
--- a/src/compas_slicer/slicers/planar_slicing/planar_slicing_cgal.py
+++ b/src/compas_slicer/slicers/planar_slicing/planar_slicing_cgal.py
@@ -28,7 +28,7 @@ def create_planar_paths_cgal(mesh, planes):
         A compas mesh.
     planes: list, compas.geometry.Plane
     """
-    if 'compas-cgal' not in packages:
+    if 'compas-cgal' not in packages and 'compas_cgal' not in packages:
         raise PluginNotInstalledError("--------ATTENTION! ----------- \
                         Compas_cgal library is missing! \
                         You can't use this planar slicing method without it. \


### PR DESCRIPTION
THe lastes compas_cgal version was renamed. I changed the check that looks if the library is installed, now it accepts both the old and the new name

<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [X] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
