### PR TITLE
Release of v0.1.1 and added raft generation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 message = Bump version to {new_version}
 commit = True
 tag = True

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,19 +11,6 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 
 **Added**
 
-**Changed**
-
-**Fixed**
-
-**Deprecated**
-
-**Removed**
-
-2021-02-12
-----------
-
-**Added**
-
 * Generate raft functionality
 
 * is_raft parameter to the Layer

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,24 @@ Unreleased
 
 **Removed**
 
+2021-02-12
+----------
+
+**Added**
+
+* Generate raft functionality
+
+* is_raft parameter to the Layer
+
+**Changed**
+
+* Simplify paths to exclude simplification of raft layers
+
+**Fixed**
+
+* Small bug in print time calculation
+
+
 
 2021-02-11
 ----------
@@ -34,6 +52,7 @@ Unreleased
 * Renamed the curved_slicer and all processes named after that (i.e. curved_preprocessor, curved_slicing_parameters, curved_print_organizer etc) to interpolation_slicer. These changes make this PR a breaking change.
 
 * Reorganized the parameters folder. A lot of parameters where considered 'curved_slicing_parameters' although they were more general. So I broke those down into separate files. More parameters will be added in the future to those files.
+
 **Fixed**
 
 * Some documentation

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-Unreleased
+0.1.1
 ----------
 
 **Added**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 
 * Simplify paths to exclude simplification of raft layers
 
+* Error raised when brim is attempted to be applied to a raft layer.
+
 **Fixed**
 
 * Small bug in print time calculation

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ project = 'COMPAS SLICER'
 year = '2020'
 author = 'Digital Building Technologies, Gramazio Kohler Research'
 copyright = '{0}, {1}'.format(year, author)
-version = release = '0.1.0'
+version = release = '0.1.1'
 
 pygments_style = 'sphinx'
 show_authors = True

--- a/docs/doc_versions.txt
+++ b/docs/doc_versions.txt
@@ -1,3 +1,4 @@
 latest
 stable
+0.1.1
 0.1.0

--- a/examples/1_planar_slicing_simple/example_1_planar_slicing_simple.py
+++ b/examples/1_planar_slicing_simple/example_1_planar_slicing_simple.py
@@ -66,8 +66,7 @@ def main():
                   raft_offset=20,
                   distance_between_paths=5,
                   direction="diagonal",
-                  raft_layers=1,
-                  raft_layer_height="default")
+                  raft_layers=1)
 
     # ==========================================================================
     # Simplify the paths by removing points with a certain threshold

--- a/examples/1_planar_slicing_simple/example_1_planar_slicing_simple.py
+++ b/examples/1_planar_slicing_simple/example_1_planar_slicing_simple.py
@@ -5,7 +5,7 @@ import logging
 import compas_slicer.utilities as utils
 from compas_slicer.pre_processing import move_mesh_to_point
 from compas_slicer.slicers import PlanarSlicer
-from compas_slicer.post_processing import generate_brim
+from compas_slicer.post_processing import generate_raft
 from compas_slicer.post_processing import simplify_paths_rdp
 from compas_slicer.post_processing import seams_smooth
 from compas_slicer.print_organization import PlanarPrintOrganizer
@@ -30,7 +30,7 @@ logging.basicConfig(format='%(levelname)s-%(message)s', level=logging.INFO)
 # ==============================================================================
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 OUTPUT_DIR = utils.get_output_directory(DATA)  # creates 'output' folder if it doesn't already exist
-MODEL = 'simple_vase_open_low_res.obj'
+MODEL = 'distorted_a_closed_mid_res.obj'
 
 
 def main():
@@ -52,14 +52,14 @@ def main():
     #          'cgal':    Very fast. Only for closed paths.
     #                     Requires additional installation (compas_cgal).
     # ==========================================================================
-    slicer = PlanarSlicer(compas_mesh, slicer_type="cgal", layer_height=1.5)
+    slicer = PlanarSlicer(compas_mesh, slicer_type="cgal", layer_height=15)
     slicer.slice_model()
 
     # ==========================================================================
     # Generate brim
     # ==========================================================================
-    generate_brim(slicer, layer_width=3.0, number_of_brim_offsets=4)
-
+    generate_raft(slicer)
+    
     # ==========================================================================
     # Simplify the paths by removing points with a certain threshold
     # change the threshold value to remove more or less points
@@ -119,7 +119,7 @@ def main():
 
     end_time = time.time()
     print("Total elapsed time", round(end_time - start_time, 2), "seconds")
-
+    
 
 if __name__ == "__main__":
     main()

--- a/examples/1_planar_slicing_simple/example_1_planar_slicing_simple.py
+++ b/examples/1_planar_slicing_simple/example_1_planar_slicing_simple.py
@@ -5,6 +5,7 @@ import logging
 import compas_slicer.utilities as utils
 from compas_slicer.pre_processing import move_mesh_to_point
 from compas_slicer.slicers import PlanarSlicer
+from compas_slicer.post_processing import generate_brim
 from compas_slicer.post_processing import generate_raft
 from compas_slicer.post_processing import simplify_paths_rdp
 from compas_slicer.post_processing import seams_smooth
@@ -30,7 +31,7 @@ logging.basicConfig(format='%(levelname)s-%(message)s', level=logging.INFO)
 # ==============================================================================
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 OUTPUT_DIR = utils.get_output_directory(DATA)  # creates 'output' folder if it doesn't already exist
-MODEL = 'distorted_a_closed_mid_res.obj'
+MODEL = 'simple_vase_open_low_res.obj'
 
 
 def main():
@@ -52,14 +53,22 @@ def main():
     #          'cgal':    Very fast. Only for closed paths.
     #                     Requires additional installation (compas_cgal).
     # ==========================================================================
-    slicer = PlanarSlicer(compas_mesh, slicer_type="cgal", layer_height=15)
+    slicer = PlanarSlicer(compas_mesh, slicer_type="cgal", layer_height=1.5)
     slicer.slice_model()
 
     # ==========================================================================
-    # Generate brim
+    # Generate brim / raft
     # ==========================================================================
-    generate_raft(slicer)
-    
+    # NOTE: Typically you would want to use either a brim OR a raft, 
+    # however, in this example both are used to explain the functionality
+    generate_brim(slicer, layer_width=3.0, number_of_brim_offsets=4)
+    generate_raft(slicer,
+                  raft_offset=20,
+                  distance_between_paths=5,
+                  direction="diagonal",
+                  raft_layers=1,
+                  raft_layer_height="default")
+
     # ==========================================================================
     # Simplify the paths by removing points with a certain threshold
     # change the threshold value to remove more or less points
@@ -119,7 +128,7 @@ def main():
 
     end_time = time.time()
     print("Total elapsed time", round(end_time - start_time, 2), "seconds")
-    
+
 
 if __name__ == "__main__":
     main()

--- a/src/compas_slicer/__init__.py
+++ b/src/compas_slicer/__init__.py
@@ -29,7 +29,7 @@ __author__ = ['Ioanna Mitropoulou and Joris Burger']
 __copyright__ = 'copyright 2020 ETH'
 __license__ = 'MIT License'
 __email__ = 'mitropoulou@arch.ethz.ch'
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 
 HERE = os.path.dirname(__file__)

--- a/src/compas_slicer/geometry/layer.py
+++ b/src/compas_slicer/geometry/layer.py
@@ -25,6 +25,8 @@ class Layer(object):
         True if this layer is a brim layer.
     number_of_brim_offsets: int
         The number of brim offsets this layer has (None if no brim).
+    is_raft: bool
+        True if this layer is a raft layer.
     """
 
     def __init__(self, paths):
@@ -42,6 +44,9 @@ class Layer(object):
         # brim
         self.is_brim = False
         self.number_of_brim_offsets = None
+
+        # raft
+        self.is_raft = False
 
     def __repr__(self):
         no_of_paths = len(self.paths) if self.paths else 0

--- a/src/compas_slicer/geometry/layer.py
+++ b/src/compas_slicer/geometry/layer.py
@@ -58,8 +58,8 @@ class Layer(object):
     def calculate_z_bounds(self):
         """ Fills in the attribute self.min_max_z_height. """
         assert len(self.paths) > 0, "You cannot calculate z_bounds because the list of paths is empty."
-        z_min = 9999999  # very big number
-        z_max = -9999999  # very small number
+        z_min = 2 ** 32  # very big number
+        z_max = -2 ** 32  # very small number
         for path in self.paths:
             for pt in path.points:
                 z_min = min(z_min, pt[2])

--- a/src/compas_slicer/post_processing/__init__.py
+++ b/src/compas_slicer/post_processing/__init__.py
@@ -32,6 +32,7 @@ Additional
     :nosignatures:
 
     generate_brim
+    generate_raft
     spiralize_contours
 
 """
@@ -54,6 +55,7 @@ from .unify_paths_orientation import *  # noqa: F401 E402 F403
 
 #  Additional
 from .generate_brim import *  # noqa: F401 E402 F403
+from .generate_raft import *  # noqa: F401 E402 F403
 from .spiralize_contours import *  # noqa: F401 E402 F403
 
 __all__ = [name for name in dir() if not name.startswith('_')]

--- a/src/compas_slicer/post_processing/generate_brim.py
+++ b/src/compas_slicer/post_processing/generate_brim.py
@@ -34,6 +34,9 @@ def generate_brim(slicer, layer_width, number_of_brim_offsets):
     #  see: https://github.com/fonttools/pyclipper/wiki/Deprecating-SCALING_FACTOR
     SCALING_FACTOR = 2 ** 32
 
+    if slicer.layers[0].is_raft:
+        raise NameError("Raft found: cannot apply brim when raft is used, choose one")
+
     # (1) --- find if slicer has vertical or horizontal layers, and select which paths are to be offset.
     if isinstance(slicer.layers[0], compas_slicer.geometry.VerticalLayer):  # Vertical layers
         # then find all paths that lie on the print platform and make them brim.
@@ -46,7 +49,7 @@ def generate_brim(slicer, layer_width, number_of_brim_offsets):
         # then replace the first layer with a brim layer.
         paths_to_offset = slicer.layers[0].paths
         has_vertical_layers = False
-
+    
     # (2) --- create new empty brim_layer
     brim_layer = Layer(paths=[])
     brim_layer.is_brim = True

--- a/src/compas_slicer/post_processing/generate_brim.py
+++ b/src/compas_slicer/post_processing/generate_brim.py
@@ -49,7 +49,7 @@ def generate_brim(slicer, layer_width, number_of_brim_offsets):
         # then replace the first layer with a brim layer.
         paths_to_offset = slicer.layers[0].paths
         has_vertical_layers = False
-    
+
     # (2) --- create new empty brim_layer
     brim_layer = Layer(paths=[])
     brim_layer.is_brim = True

--- a/src/compas_slicer/post_processing/generate_raft.py
+++ b/src/compas_slicer/post_processing/generate_raft.py
@@ -21,7 +21,7 @@ __all__ = ['generate_raft']
 def generate_raft(slicer,
                   raft_offset=10,
                   distance_between_paths=10,
-                  direction="horizontal",
+                  direction="xy_diagonal",
                   raft_layers=1,
                   raft_layer_height=None):
     """Creates a raft.
@@ -35,9 +35,9 @@ def generate_raft(slicer,
     distance_between_paths: float
         Distance (in mm) between the printed lines of the raft. Defaults to 10mm
     direction: str
-        horizontal: Create a raft in the horizontal direction
-        vertical: Create a raft in the vertical direction
-        diagonal: Create a raft int the diagonal direction
+        x_axis: Create a raft aligned with the x_axis
+        y_axis: Create a raft aligned with the y_axis
+        xy_diagonal: Create a raft int the diagonal direction in the xy_plane
     raft_layers: int
         Number of raft layers to add. Defaults to 1
     raft_layer_height: float
@@ -84,7 +84,7 @@ def generate_raft(slicer,
     raft_start_pt = Point(bb_xy_offset[0][0], bb_xy_offset[0][1], bb_xy_offset[0][2])
 
     # create starting line for diagonal direction
-    if direction == "diagonal":
+    if direction == "xy_diagonal":
         c = math.sqrt(2*(distance_between_paths**2))
 
         pt1 = Point(raft_start_pt[0] + c, raft_start_pt[1], raft_start_pt[2])
@@ -103,11 +103,11 @@ def generate_raft(slicer,
         raft_points = []
 
         # create raft points depending on the chosen direction
-        while True and iter < 9999:  # to avoid infinite while loop in case something is not correct
+        while iter < 9999:  # to avoid infinite while loop in case something is not correct
             # ===============
             # VERTICAL RAFT
             # ===============
-            if direction == "vertical":
+            if direction == "y_axis":
                 raft_pt1 = Point(raft_start_pt[0] + iter*distance_between_paths, raft_start_pt[1], raft_start_pt[2] + i*raft_layer_height)
                 raft_pt2 = Point(raft_start_pt[0] + iter*distance_between_paths, raft_start_pt[1] + y_range, raft_start_pt[2] + i*raft_layer_height)
 
@@ -117,7 +117,7 @@ def generate_raft(slicer,
             # ===============
             # HORIZONTAL RAFT
             # ===============
-            elif direction == "horizontal":
+            elif direction == "x_axis":
                 raft_pt1 = Point(raft_start_pt[0], raft_start_pt[1] + iter*distance_between_paths, raft_start_pt[2] + i*raft_layer_height)
                 raft_pt2 = Point(raft_start_pt[0] + x_range, raft_start_pt[1] + iter*distance_between_paths, raft_start_pt[2] + i*raft_layer_height)
 
@@ -127,7 +127,7 @@ def generate_raft(slicer,
             # ===============
             # DIAGONAL RAFT
             # ===============
-            elif direction == "diagonal":
+            elif direction == "xy_diagonal":
                 # create offset of the initial diagonal line
                 offset_l = offset_line(line, iter*distance_between_paths, Vector(0, 0, -1))
 

--- a/src/compas_slicer/post_processing/generate_raft.py
+++ b/src/compas_slicer/post_processing/generate_raft.py
@@ -1,0 +1,98 @@
+import logging
+from compas.geometry._core import distance
+
+import pyclipper
+from pyclipper import scale_from_clipper, scale_to_clipper
+
+import compas_slicer
+from compas_slicer.geometry import Layer
+from compas_slicer.geometry import Path
+
+from compas.geometry import Point
+from compas.geometry import bounding_box_xy
+from compas.geometry import offset_polygon
+
+from compas_slicer.post_processing import seams_align
+
+logger = logging.getLogger('logger')
+
+__all__ = ['generate_raft']
+
+
+def generate_raft(slicer, raft_offset=10, distance_between_lines=10, direction="x_axis"):
+    """Creates a raft.
+
+    Parameters
+    ----------
+    slicer: :class:`compas_slicer.slicers.BaseSlicer`
+        An instance of one of the compas_slicer.slicers.BaseSlicer classes.
+    raft_offset: float
+        Distance (in mm) that the raft should be offsetted from the first layer.
+    distance_between_lines: float
+        Distance (in mm) between the printed lines of the raft.
+    direction: str
+        x_axis: Aligns the raft with the x axis
+        y_axis: Aligns the raft with the y_axis
+    """
+
+    logger.info("Generating raft")
+
+    # find if slicer has vertical or horizontal layers, and select which paths are to be offset.
+    if isinstance(slicer.layers[0], compas_slicer.geometry.VerticalLayer):  # Vertical layers
+        # then find all paths that lie on the print platform and make them brim.
+        paths_to_offset, _ = slicer.find_vertical_layers_with_first_path_on_base()
+        has_vertical_layers = True
+
+    else:  # Horizontal layers
+        # then replace the first layer with a raft layer.
+        paths_to_offset = slicer.layers[0].paths
+        has_vertical_layers = False
+
+    # get flat lists of points in bottom layer
+    all_pts = []
+    for path in paths_to_offset:
+        for pt in path.points:
+            all_pts.append(pt)
+
+    # get xy bounding box and create offset
+    bb_xy = bounding_box_xy(all_pts)
+    bb_xy_offset = offset_polygon(bb_xy, -raft_offset)
+
+    # calculate x range, y range and number of steps
+    x_range = abs(bb_xy_offset[0][0] - bb_xy_offset[1][0])
+    y_range = abs(bb_xy_offset[0][1] - bb_xy_offset[3][1])
+    if direction == "y_axis":
+        no_of_steps = int(x_range/distance_between_lines)
+    elif direction == "x_axis":
+        no_of_steps = int(y_range/distance_between_lines)
+
+    # get raft start point
+    raft_start_pt = bb_xy_offset[0]
+
+    raft_points = []
+    for i in range(no_of_steps+1):
+        # create raft points depending on the chosen direction
+        if direction == "y_axis":
+            raft_pt1 = Point(raft_start_pt[0] + i*distance_between_lines, raft_start_pt[1], raft_start_pt[2])
+            raft_pt2 = Point(raft_start_pt[0] + i*distance_between_lines, raft_start_pt[1] + y_range, raft_start_pt[2])
+        elif direction == "x_axis":
+            raft_pt1 = Point(raft_start_pt[0], raft_start_pt[1] + i*distance_between_lines, raft_start_pt[2])
+            raft_pt2 = Point(raft_start_pt[0] + x_range, raft_start_pt[1] + i*distance_between_lines, raft_start_pt[2])
+        # append to list alternating
+        if i % 2 == 0:
+            raft_points.extend((raft_pt1, raft_pt2))
+        else:
+            raft_points.extend((raft_pt2, raft_pt1))
+
+    # create raft layer
+    raft_layer = Layer([Path(raft_points, is_closed=False)])
+
+    # add the raft layer to the slicer
+    if not has_vertical_layers:
+        slicer.layers[0] = raft_layer  # replace first layer
+    else:
+        slicer.layers.insert(0, raft_layer)  # insert brim layer as the first layer of the slicer
+
+
+if __name__ == "__main__":
+    pass

--- a/src/compas_slicer/post_processing/generate_raft.py
+++ b/src/compas_slicer/post_processing/generate_raft.py
@@ -23,7 +23,7 @@ def generate_raft(slicer,
                   distance_between_paths=10,
                   direction="horizontal",
                   raft_layers=1,
-                  raft_layer_height="default"):
+                  raft_layer_height=None):
     """Creates a raft.
 
     Parameters
@@ -45,7 +45,7 @@ def generate_raft(slicer,
     """
 
     # check if a raft_layer_height is specified, if not, use the slicer.layer_height value
-    if raft_layer_height == "default":
+    if not raft_layer_height:
         raft_layer_height = slicer.layer_height
 
     logger.info("Generating raft")

--- a/src/compas_slicer/post_processing/generate_raft.py
+++ b/src/compas_slicer/post_processing/generate_raft.py
@@ -1,8 +1,4 @@
 import logging
-from compas.geometry._core import distance
-
-import pyclipper
-from pyclipper import scale_from_clipper, scale_to_clipper
 
 import compas_slicer
 from compas_slicer.geometry import Layer
@@ -12,14 +8,17 @@ from compas.geometry import Point
 from compas.geometry import bounding_box_xy
 from compas.geometry import offset_polygon
 
-from compas_slicer.post_processing import seams_align
-
 logger = logging.getLogger('logger')
 
 __all__ = ['generate_raft']
 
 
-def generate_raft(slicer, raft_offset=10, distance_between_lines=10, direction="x_axis"):
+def generate_raft(slicer,
+                  raft_offset=10,
+                  distance_between_paths=10,
+                  direction="x_axis",
+                  raft_layers=1,
+                  raft_layer_height="default"):
     """Creates a raft.
 
     Parameters
@@ -27,13 +26,21 @@ def generate_raft(slicer, raft_offset=10, distance_between_lines=10, direction="
     slicer: :class:`compas_slicer.slicers.BaseSlicer`
         An instance of one of the compas_slicer.slicers.BaseSlicer classes.
     raft_offset: float
-        Distance (in mm) that the raft should be offsetted from the first layer.
-    distance_between_lines: float
-        Distance (in mm) between the printed lines of the raft.
+        Distance (in mm) that the raft should be offsetted from the first layer. Defaults to 10mm
+    distance_between_paths: float
+        Distance (in mm) between the printed lines of the raft. Defaults to 10mm
     direction: str
         x_axis: Aligns the raft with the x axis
         y_axis: Aligns the raft with the y_axis
+    raft_layers: int
+        Number of raft layers to add. Defaults to 1
+    raft_layer_height: float
+        Layer height of the raft layers. Defaults to same value as used in the slicer.
     """
+
+    # check if a raft_layer_height is specified, if not, use the slicer.layer_height value
+    if raft_layer_height == "default":
+        raft_layer_height = slicer.layer_height
 
     logger.info("Generating raft")
 
@@ -41,12 +48,10 @@ def generate_raft(slicer, raft_offset=10, distance_between_lines=10, direction="
     if isinstance(slicer.layers[0], compas_slicer.geometry.VerticalLayer):  # Vertical layers
         # then find all paths that lie on the print platform and make them brim.
         paths_to_offset, _ = slicer.find_vertical_layers_with_first_path_on_base()
-        has_vertical_layers = True
 
     else:  # Horizontal layers
         # then replace the first layer with a raft layer.
         paths_to_offset = slicer.layers[0].paths
-        has_vertical_layers = False
 
     # get flat lists of points in bottom layer
     all_pts = []
@@ -54,45 +59,49 @@ def generate_raft(slicer, raft_offset=10, distance_between_lines=10, direction="
         for pt in path.points:
             all_pts.append(pt)
 
-    # get xy bounding box and create offset
+    # get xy bounding box of bottom layer and create offset
     bb_xy = bounding_box_xy(all_pts)
     bb_xy_offset = offset_polygon(bb_xy, -raft_offset)
 
-    # calculate x range, y range and number of steps
+    # calculate x range, y range, and number of steps
     x_range = abs(bb_xy_offset[0][0] - bb_xy_offset[1][0])
     y_range = abs(bb_xy_offset[0][1] - bb_xy_offset[3][1])
     if direction == "y_axis":
-        no_of_steps = int(x_range/distance_between_lines)
+        no_of_steps = int(x_range/distance_between_paths)
     elif direction == "x_axis":
-        no_of_steps = int(y_range/distance_between_lines)
+        no_of_steps = int(y_range/distance_between_paths)
 
-    # get raft start point
-    raft_start_pt = bb_xy_offset[0]
+    # get raft start point with correct z height
+    raft_start_pt = Point(bb_xy_offset[0][0], bb_xy_offset[0][1], slicer.layers[0].paths[0].points[0][2])
 
-    raft_points = []
-    for i in range(no_of_steps+1):
-        # create raft points depending on the chosen direction
-        if direction == "y_axis":
-            raft_pt1 = Point(raft_start_pt[0] + i*distance_between_lines, raft_start_pt[1], raft_start_pt[2])
-            raft_pt2 = Point(raft_start_pt[0] + i*distance_between_lines, raft_start_pt[1] + y_range, raft_start_pt[2])
-        elif direction == "x_axis":
-            raft_pt1 = Point(raft_start_pt[0], raft_start_pt[1] + i*distance_between_lines, raft_start_pt[2])
-            raft_pt2 = Point(raft_start_pt[0] + x_range, raft_start_pt[1] + i*distance_between_lines, raft_start_pt[2])
-        # append to list alternating
-        if i % 2 == 0:
-            raft_points.extend((raft_pt1, raft_pt2))
-        else:
-            raft_points.extend((raft_pt2, raft_pt1))
+    # move all points in the slicer up so that raft layers can be inserted
+    for i, layer in enumerate(slicer.layers):
+        for j, path in enumerate(layer.paths):
+            for k, pt in enumerate(path.points):
+                slicer.layers[i].paths[j].points[k] = Point(pt[0], pt[1], pt[2] + (raft_layers-1)*raft_layer_height)
 
-    # create raft layer
-    raft_layer = Layer([Path(raft_points, is_closed=False)])
+    for i in range(raft_layers):
+        raft_points = []
 
-    # add the raft layer to the slicer
-    if not has_vertical_layers:
-        slicer.layers[0] = raft_layer  # replace first layer
-    else:
-        slicer.layers.insert(0, raft_layer)  # insert brim layer as the first layer of the slicer
+        for j in range(no_of_steps+1):
+            # create raft points depending on the chosen direction
+            if direction == "y_axis":
+                raft_pt1 = Point(raft_start_pt[0] + j*distance_between_paths, raft_start_pt[1], raft_start_pt[2] + i*raft_layer_height)
+                raft_pt2 = Point(raft_start_pt[0] + j*distance_between_paths, raft_start_pt[1] + y_range, raft_start_pt[2] + i*raft_layer_height)
+            elif direction == "x_axis":
+                raft_pt1 = Point(raft_start_pt[0], raft_start_pt[1] + j*distance_between_paths, raft_start_pt[2] + i*raft_layer_height)
+                raft_pt2 = Point(raft_start_pt[0] + x_range, raft_start_pt[1] + j*distance_between_paths, raft_start_pt[2] + i*raft_layer_height)
 
+            # append to list alternating
+            if j % 2 == 0:
+                raft_points.extend((raft_pt1, raft_pt2))
+            else:
+                raft_points.extend((raft_pt2, raft_pt1))
+
+        # create raft layer
+        raft_layer = Layer([Path(raft_points, is_closed=False)])
+        # insert raft layer in the correct position into the slicer
+        slicer.layers.insert(i, raft_layer)
 
 if __name__ == "__main__":
     pass

--- a/src/compas_slicer/post_processing/generate_raft.py
+++ b/src/compas_slicer/post_processing/generate_raft.py
@@ -1,8 +1,6 @@
 import logging
 import math
 
-from compas.geometry._core import distance
-
 import compas_slicer
 from compas_slicer.geometry import Layer
 from compas_slicer.geometry import Path
@@ -174,6 +172,7 @@ def generate_raft(slicer,
         raft_layer.is_raft = True
         # insert raft layer in the correct position into the slicer
         slicer.layers.insert(i, raft_layer)
+
 
 if __name__ == "__main__":
     pass

--- a/src/compas_slicer/post_processing/simplify_paths_rdp.py
+++ b/src/compas_slicer/post_processing/simplify_paths_rdp.py
@@ -31,11 +31,12 @@ def simplify_paths_rdp(slicer, threshold):
 
     with progressbar.ProgressBar(max_value=len(slicer.layers)) as bar:
         for i, layer in enumerate(slicer.layers):
-            for path in layer.paths:
-                pts_rdp = rdp.rdp(np.array(path.points), epsilon=threshold)
-                path.points = [Point(pt[0], pt[1], pt[2]) for pt in pts_rdp]
-                remaining_pts_num += len(path.points)
-                bar.update(i)
+            if not layer.is_raft:  # no simplification necessary for raft layer
+                for path in layer.paths:
+                    pts_rdp = rdp.rdp(np.array(path.points), epsilon=threshold)
+                    path.points = [Point(pt[0], pt[1], pt[2]) for pt in pts_rdp]
+                    remaining_pts_num += len(path.points)
+                    bar.update(i)
         logger.info('%d Points remaining after rdp simplification' % remaining_pts_num)
 
 

--- a/src/compas_slicer/print_organization/base_print_organizer.py
+++ b/src/compas_slicer/print_organization/base_print_organizer.py
@@ -92,7 +92,7 @@ class BasePrintOrganizer(object):
                 for path_key in self.printpoints_dict[layer_key]:
                     for prev, curr in pairwise(self.printpoints_dict[layer_key][path_key]):
                         length = distance_point_point(prev.pt, curr.pt)
-                        total_time += length * curr.velocity * 0.001
+                        total_time += length / curr.velocity
             return total_time
 
     def number_of_paths_on_layer(self, layer_index):


### PR DESCRIPTION
First release of compas_slicer by semantic versioning, version 0.1.1. 
Added raft generation and few minor changes.

### What type of change is this?

- [X] Bug fix in a **backwards-compatible** manner.
- [X] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [X] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [X] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [X] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added necessary documentation (if appropriate)
