### PR TITLE
Escaped _ in bibtex entry to avoid subscript

### DIFF
--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -9,7 +9,7 @@ Citing
 ::
 
     @misc{compas-slicer,
-        title  = {{COMPAS_SLICER}: Slicing functionality for COMPAS},
+        title  = {{COMPAS\_SLICER}: Slicing functionality for COMPAS},
         author = {Ioanna Mitropoulou and Joris Burger},
         note   = {https://compas.dev/compas_slicer/},
         year   = {2020}


### PR DESCRIPTION

![image](https://github.com/compas-dev/compas_slicer/assets/14882117/d42a4e92-f4ab-4f72-9fd9-d22ecb134805)

Top is before, bottom is after. in TeX _ changes following letter to subscript.

### What type of change is this?

- [x] Other (e.g. doc update, configuration, etc)


